### PR TITLE
feat: add wait-retry mode with timeout configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 * 提供线程安全的存储后端：Redis（基于 Lua 实现限流算法）、内存（基于 threading.RLock，支持 Key 过期淘汰）。
 * 支持多种限流算法：[固定窗口](https://github.com/ZhuoZhuoCrayon/throttled-py/tree/main/docs/basic#21-%E5%9B%BA%E5%AE%9A%E7%AA%97%E5%8F%A3%E8%AE%A1%E6%95%B0%E5%99%A8)、[滑动窗口](https://github.com/ZhuoZhuoCrayon/throttled-py/blob/main/docs/basic/readme.md#22-%E6%BB%91%E5%8A%A8%E7%AA%97%E5%8F%A3)、[令牌桶](https://github.com/ZhuoZhuoCrayon/throttled-py/blob/main/docs/basic/readme.md#23-%E4%BB%A4%E7%89%8C%E6%A1%B6)、[漏桶](https://github.com/ZhuoZhuoCrayon/throttled-py/blob/main/docs/basic/readme.md#24-%E6%BC%8F%E6%A1%B6) & [通用信元速率算法（Generic Cell Rate Algorithm, GCRA）](https://github.com/ZhuoZhuoCrayon/throttled-py/blob/main/docs/basic/readme.md#25-gcra)。
-* 提供灵活的限流策略、配额设置 API，文档详尽。
-* 支持装饰器模式。
+* 提供灵活的限流算法、配额设置，文档详尽。
+* 支持即刻返回及等待重试，提供函数调用、装饰器模式。
 * 良好的性能，单次限流 API 执行耗时换算如下（详见 [Benchmarks](https://github.com/ZhuoZhuoCrayon/throttled-py?tab=readme-ov-file#-benchmarks)）：
   * 内存：约为 2.5 ~ 4.5 次 `dict[key] += 1` 操作。
   * Redis：约为 1.06 ~ 1.37 次 `INCRBY key increment` 操作。
@@ -47,7 +47,7 @@ from throttled import RateLimiterType, Throttled, rate_limter, store, utils
 throttle = Throttled(
     # 📈 使用令牌桶作为限流算法。
     using=RateLimiterType.TOKEN_BUCKET.value,
-    # 🪣 设置配额：每分钟填充 1000 个 Token（limit），桶大小为 1000（burst）。
+    # 🪣 设置配额：每秒填充 1000 个 Token（limit），桶大小为 1000（burst）。
     quota=rate_limter.per_sec(1_000, burst=1_000),
     # 📁 使用内存作为存储
     store=store.MemoryStore(),
@@ -112,6 +112,38 @@ except exceptions.LimitedError as exc:
     # 在异常中获取限流结果：RateLimitResult(limited=True, 
     # state=RateLimitState(limit=1, remaining=0, reset_after=60))
     print(exc.rate_limit_result)
+```
+
+#### 等待重试
+
+默认情况下，限流判断将「即刻」返回 [**RateLimitResult**](https://github.com/ZhuoZhuoCrayon/throttled-py?tab=readme-ov-file#1ratelimitresult)。
+
+你可以通过  **`timeout`** 指定等待重试的超时时间，限流器将根据  [**RateLimitState**](https://github.com/ZhuoZhuoCrayon/throttled-py?tab=readme-ov-file#2ratelimitstate) 的 `retry_after` 进行若干次等待及重试。
+
+一旦请求通过或超时，返回最后一次的  [**RateLimitResult**](https://github.com/ZhuoZhuoCrayon/throttled-py?tab=readme-ov-file#1ratelimitresult)。
+
+```python
+from throttled import RateLimiterType, Throttled, rate_limter, utils
+
+throttle = Throttled(
+    using=RateLimiterType.TOKEN_BUCKET.value,
+    quota=rate_limter.per_sec(1_000, burst=1_000),
+    # ⏳ 设置超时时间为 1 秒，表示允许等待重试，等待时间超过 1 秒返回最后一次限流结果。
+    timeout=1,
+)
+
+def call_api() -> bool:
+    # ⬆️⏳ 函数调用传入 timeout 将覆盖全局设置的 timeout。
+    result = throttle.limit("/ping", cost=1, timeout=1)
+    return result.limited
+
+if __name__ == "__main__":
+    # 👇 实际 QPS 接近预设容量（1_000 req/s）：
+    # ✅ Total: 10000, 🕒 Latency: 14.7883 ms/op, 🚀Throughput: 1078 req/s (--)
+    # ❌ Denied: 54 requests
+    benchmark: utils.Benchmark = utils.Benchmark()
+    denied_num: int = sum(benchmark.concurrent(call_api, 10_000, workers=16))
+    print(f"❌ Denied: {denied_num} requests")
 ```
 
 ### 2）指定存储后端

--- a/examples/basic/quickstart_example.py
+++ b/examples/basic/quickstart_example.py
@@ -3,7 +3,7 @@ from throttled import RateLimiterType, Throttled, rate_limter, store, utils
 throttle = Throttled(
     # 📈 使用令牌桶作为限流算法。
     using=RateLimiterType.TOKEN_BUCKET.value,
-    # 🪣 设置配额：每分钟填充 1000 个 Token（limit），桶大小为 1000（burst）。
+    # 🪣 设置配额：每秒填充 1_000 个 Token（limit），桶大小为 1_000（burst）。
     quota=rate_limter.per_sec(1_000, burst=1_000),
     # 📁 使用内存作为存储
     store=store.MemoryStore(),

--- a/examples/basic/timeout_example.py
+++ b/examples/basic/timeout_example.py
@@ -1,0 +1,23 @@
+from throttled import RateLimiterType, Throttled, rate_limter, utils
+
+throttle = Throttled(
+    using=RateLimiterType.TOKEN_BUCKET.value,
+    quota=rate_limter.per_sec(1_000, burst=1_000),
+    # ⏳ 设置超时时间为 1 秒，表示允许等待重试，等待时间超过 1 秒返回最后一次限流结果。
+    timeout=1,
+)
+
+
+def call_api() -> bool:
+    # ⬆️⏳ 函数调用传入 timeout 将覆盖全局设置的 timeout。
+    result = throttle.limit("/ping", cost=1, timeout=1)
+    return result.limited
+
+
+if __name__ == "__main__":
+    # 👇 实际 QPS 接近预设容量（1_000 req/s）：
+    # ✅ Total: 10000, 🕒 Latency: 14.7883 ms/op, 🚀Throughput: 1078 req/s (--)
+    # ❌ Denied: 54 requests
+    benchmark: utils.Benchmark = utils.Benchmark()
+    denied_num: int = sum(benchmark.concurrent(call_api, 10_000, workers=16))
+    print(f"❌ Denied: {denied_num} requests")

--- a/tests/test_throttled.py
+++ b/tests/test_throttled.py
@@ -1,10 +1,11 @@
-from typing import Callable
+from typing import Any, Callable, Dict, Type
 
 import pytest
 
-from throttled import Throttled, rate_limter, store
+from throttled import Throttled, per_sec, rate_limter, store
 from throttled.constants import RateLimiterType
-from throttled.exceptions import LimitedError
+from throttled.exceptions import BaseThrottledError, DataError, LimitedError
+from throttled.utils import now_sec_f
 
 
 @pytest.fixture
@@ -26,3 +27,72 @@ class TestThrottled:
         assert decorated_demo(1, 2) == 3
         with pytest.raises(LimitedError):
             decorated_demo(2, 3)
+
+    @pytest.mark.parametrize(
+        "constructor_kwargs,exc,match",
+        [
+            [{"timeout": -2}, DataError, "Invalid timeout"],
+            [{"timeout": "a"}, DataError, "Invalid timeout"],
+            [{"timeout": -1.1}, DataError, "Invalid timeout"],
+            [{"timeout": 0}, DataError, "Invalid timeout"],
+            [{"timeout": 0.0}, DataError, "Invalid timeout"],
+            [{"timeout": -0.0}, DataError, "Invalid timeout"],
+        ],
+    )
+    def test_constructor__raise(
+        self,
+        constructor_kwargs: Dict[str, Any],
+        exc: Type[BaseThrottledError],
+        match: str,
+    ):
+        with pytest.raises(exc, match=match):
+            Throttled(**constructor_kwargs)
+
+    def test_get_key(self):
+        throttle: Throttled = Throttled(key="key")
+        assert throttle._get_key() == "key"
+        assert throttle._get_key(key="override_key") == "override_key"
+        assert throttle._get_key(key="") == "key"
+        assert throttle._get_key(key=None) == "key"
+
+        for _throttle in [Throttled(), Throttled(key=""), Throttled(key=None)]:
+            with pytest.raises(DataError, match="Invalid key"):
+                _throttle(lambda _: None)
+
+            with pytest.raises(DataError, match="Invalid key"):
+                _throttle._get_key()
+
+            with pytest.raises(DataError, match="Invalid key"):
+                _throttle._get_key(key="")
+
+            assert _throttle._get_key(key="override_key") == "override_key"
+
+    def test_get_timeout(self):
+        throttle: Throttled = Throttled(timeout=10)
+        assert throttle._get_timeout() == 10
+        assert throttle._get_timeout(timeout=20) == 20
+        assert throttle._get_timeout(timeout=-1) == -1
+
+        with pytest.raises(DataError, match="Invalid timeout"):
+            throttle._get_timeout(timeout=0)
+
+        with pytest.raises(DataError, match="Invalid timeout"):
+            throttle._get_timeout(timeout=-2)
+
+    def test_limit__timeout(self):
+        throttle: Throttled = Throttled(timeout=1, quota=per_sec(1))
+        assert not throttle.limit("key").limited
+
+        start_time: float = now_sec_f()
+        assert not throttle.limit("key").limited
+        assert 1 <= now_sec_f() - start_time < 2
+
+        # case: retry_after > timeout
+        start_time: float = now_sec_f()
+        assert throttle.limit("key", cost=2).limited
+        assert 0 <= now_sec_f() - start_time < 0.1
+
+        # case: timeout < retry_after
+        start_time: float = now_sec_f()
+        assert throttle.limit("key", timeout=0.5).limited
+        assert 0 <= now_sec_f() - start_time < 0.1

--- a/throttled/throttled.py
+++ b/throttled/throttled.py
@@ -194,7 +194,7 @@ class Throttled:
         # TODO: When cost > limit, return early instead of waiting.
         start_time: float = now_sec_f()
         while True:
-            if result.state.retry_after > timeout or timeout < result.state.retry_after:
+            if result.state.retry_after > timeout:
                 break
 
             self._wait(timeout, result.state.retry_after)

--- a/throttled/throttled.py
+++ b/throttled/throttled.py
@@ -1,4 +1,5 @@
 import threading
+import time
 from typing import Callable, Optional, Type
 
 from .constants import RateLimiterType
@@ -13,12 +14,21 @@ from .rate_limter import (
 )
 from .store import BaseStore, MemoryStore
 from .types import KeyT, RateLimiterTypeT
+from .utils import now_sec_f
 
 
 class Throttled:
+    # Non-blocking mode constant
+    _NON_BLOCKING: float = -1
+    # Interval between retries in seconds
+    _WAIT_INTERVAL: float = 0.5
+    # Minimum interval between retries in seconds
+    _WAIT_MIN_INTERVAL: float = 0.2
+
     def __init__(
         self,
         key: Optional[KeyT] = None,
+        timeout: Optional[float] = None,
         using: Optional[RateLimiterTypeT] = None,
         quota: Optional[Quota] = None,
         store: Optional[BaseStore] = None,
@@ -26,6 +36,11 @@ class Throttled:
         """Initializes the Throttled class.
         :param key: The unique identifier for the rate limit subject.
                     eg: user ID or IP address.
+        :param timeout: Maximum wait time in seconds when rate limit is
+                        exceeded.
+                        (Default) If set to -1, it will return immediately.
+                        Otherwise, it will block until the request can be
+                        processed or the timeout is reached.
         :param using: The type of rate limiter to use, default: token_bucket.
         :param quota: The quota for the rate limiter, default: 60 requests per minute.
         :param store: The store to use for the rate limiter, default: MemoryStore.
@@ -34,6 +49,12 @@ class Throttled:
         # TODO Support extract key from params.
         # TODO Support get cost weight by key.
         self.key: Optional[str] = key
+
+        if timeout is None:
+            timeout = self._NON_BLOCKING
+        self.timeout: float = timeout
+        self._validate_timeout(self.timeout)
+
         self._quota: Quota = quota or per_min(60)
         self._store: BaseStore = store or MemoryStore()
         self._limiter_cls: Type[BaseRateLimiter] = RateLimiterRegistry.get(
@@ -60,11 +81,11 @@ class Throttled:
         """Decorator to apply rate limiting to a function."""
 
         if not self.key:
-            raise DataError("Decorator requires a non-empty key.")
+            raise DataError(f"Invalid key: {self.key}, must be a non-empty key.")
 
         def _inner(*args, **kwargs):
             # TODO Add options to ignore state.
-            result: RateLimitResult = self.limit(self.key)
+            result: RateLimitResult = self.limit()
             if result.limited:
                 raise LimitedError(rate_limit_result=result)
             return func(*args, **kwargs)
@@ -82,21 +103,111 @@ class Throttled:
             return
 
         raise DataError(
-            "Invalid cost: {cost}, Must be an integer greater "
-            "than 0.".format(cost=cost)
+            f"Invalid cost: {cost}, must be an integer greater than 0.".format(cost=cost)
         )
 
-    def limit(self, key: KeyT, cost: int = 1) -> RateLimitResult:
+    @classmethod
+    def _validate_timeout(cls, timeout: float) -> None:
+        """Validate the timeout value.
+        :param timeout: Maximum wait time in seconds when rate limit is exceeded.
+        :raise: DataError if the timeout is not a positive float or -1(non-blocking).
+        """
+
+        if timeout == cls._NON_BLOCKING:
+            return
+
+        if (isinstance(timeout, float) or isinstance(timeout, int)) and timeout > 0:
+            return
+
+        raise DataError(
+            f"Invalid timeout: {timeout}, must be a positive float or -1(non-blocking)."
+        )
+
+    def _get_key(self, key: Optional[KeyT] = None) -> KeyT:
+        # Use the provided key if available.
+        if key:
+            return key
+
+        if self.key:
+            return self.key
+
+        raise DataError(f"Invalid key: {key}, must be a non-empty key.")
+
+    def _get_timeout(self, timeout: Optional[float] = None) -> float:
+        if timeout is not None:
+            self._validate_timeout(timeout)
+            return timeout
+
+        return self.timeout
+
+    def _wait(self, timeout: float, retry_after: float) -> None:
+        """Wait for the specified timeout or until retry_after is reached."""
+        if retry_after <= 0:
+            return
+
+        start_time: float = now_sec_f()
+        while True:
+            # WAIT_INTERVAL: Chunked waiting interval to avoid long blocking periods.
+            # Also helps reduce actual wait time considering thread context switches.
+            # WAIT_MIN_INTERVAL: Minimum wait interval to prevent busy-waiting.
+            sleep_time: float = max(
+                min(retry_after, self._WAIT_INTERVAL), self._WAIT_MIN_INTERVAL
+            )
+
+            # Sleep for the specified time.
+            time.sleep(sleep_time)
+
+            # Calculate the elapsed time since the start time.
+            # Due to additional context switching overhead in multithread contexts,
+            # we don't directly use sleep_time to calculate elapsed time.
+            # Instead, we re-fetch the current time and subtract it from the start time.
+            elapsed: float = now_sec_f() - start_time
+            if elapsed >= retry_after or elapsed >= timeout:
+                break
+
+    def limit(
+        self, key: Optional[KeyT] = None, cost: int = 1, timeout: Optional[float] = None
+    ) -> RateLimitResult:
         """Apply rate limiting logic to a given key with a specified cost.
         :param key: The unique identifier for the rate limit subject.
                     eg: user ID or IP address.
+                    Overrides the instance key if provided.
         :param cost: The cost of the current request in terms of how much
                      of the rate limit quota it consumes.
+        :param timeout: Maximum wait time in seconds when rate limit is
+                        exceeded.
+                        If set to -1, it will return immediately.
+                        Otherwise, it will block until the request can
+                        be processed or the timeout is reached.
+                        Overrides the instance timeout if provided.
         :return: RateLimitResult: The result of the rate limiting check.
-        :raise: DataError
+        :raise: DataError if invalid parameters.
         """
         self._validate_cost(cost)
-        return self._get_limiter().limit(key, cost)
+
+        key: KeyT = self._get_key(key)
+        timeout: float = self._get_timeout(timeout)
+        result: RateLimitResult = self._get_limiter().limit(key, cost)
+        if timeout == self._NON_BLOCKING or not result.limited:
+            return result
+
+        # TODO: When cost > limit, return early instead of waiting.
+        start_time: float = now_sec_f()
+        while True:
+            if result.state.retry_after > timeout or timeout < result.state.retry_after:
+                break
+
+            self._wait(timeout, result.state.retry_after)
+
+            result = self._get_limiter().limit(key, cost)
+            if not result.limited:
+                break
+
+            elapsed: float = now_sec_f() - start_time
+            if elapsed >= timeout:
+                break
+
+        return result
 
     def peek(self, key: KeyT) -> RateLimitState:
         """Retrieve the current state of rate limiter for the given key

--- a/throttled/utils.py
+++ b/throttled/utils.py
@@ -11,6 +11,10 @@ def now_sec() -> int:
     return int(time.time())
 
 
+def now_sec_f() -> float:
+    return time.time()
+
+
 def now_ms() -> int:
     return int(time.time() * 1000)
 


### PR DESCRIPTION
- Implement wait-retry behavior when timeout is specified
- Support both global and function-level timeout override
- Automatically retry based on RateLimitState.retry_after
- Return final RateLimitResult when request is allowed or timeout reached # Reviewed, transaction id: 37575