### PR TITLE
fix: remove deprecated 'rate_limter' misspelled alias (#38)

### DIFF
--- a/tests/rate_limiter/test_base.py
+++ b/tests/rate_limiter/test_base.py
@@ -3,32 +3,32 @@ from typing import Any, Callable, Dict, Optional
 
 import pytest
 
-from throttled import Quota, rate_limter
+from throttled import Quota, rate_limiter
 
 
 class TestQuota:
     @pytest.mark.parametrize(
         "per_xx,constructor_kwargs,expect",
         [
-            [rate_limter.per_sec, {"limit": 10}, {"limit": 10, "burst": 10, "sec": 1}],
-            [rate_limter.per_min, {"limit": 10}, {"limit": 10, "burst": 10, "sec": 60}],
+            [rate_limiter.per_sec, {"limit": 10}, {"limit": 10, "burst": 10, "sec": 1}],
+            [rate_limiter.per_min, {"limit": 10}, {"limit": 10, "burst": 10, "sec": 60}],
             [
-                rate_limter.per_hour,
+                rate_limiter.per_hour,
                 {"limit": 10},
                 {"limit": 10, "burst": 10, "sec": 3600},
             ],
             [
-                rate_limter.per_day,
+                rate_limiter.per_day,
                 {"limit": 10},
                 {"limit": 10, "burst": 10, "sec": 86400},
             ],
             [
-                rate_limter.per_week,
+                rate_limiter.per_week,
                 {"limit": 10},
                 {"limit": 10, "burst": 10, "sec": 604800},
             ],
             [
-                rate_limter.per_sec,
+                rate_limiter.per_sec,
                 {"limit": 10, "burst": 5},
                 {"limit": 10, "burst": 5, "sec": 1},
             ],
@@ -46,7 +46,7 @@ class TestQuota:
         assert quota.get_period_sec() == expect["sec"]
 
     def test_per_duration(self):
-        quota: Quota = rate_limter.per_duration(
+        quota: Quota = rate_limiter.per_duration(
             timedelta(minutes=2), limit=120, burst=150
         )
         assert quota.burst == 150

--- a/throttled/__init__.py
+++ b/throttled/__init__.py
@@ -1,5 +1,4 @@
 from . import rate_limiter
-from . import rate_limiter as rate_limter
 from .constants import RateLimiterType
 from .rate_limiter import (
     BaseRateLimiter,
@@ -34,10 +33,6 @@ __all__ = [
     "types",
     "utils",
     # rate_limiter
-    # Compatibility note: Use the correct spelling of "rate_limiter" and keep the
-    # misspelled "rate_limter" before v2.0.0.
-    # Related issue: https://github.com/ZhuoZhuoCrayon/throttled-py/issues/38.
-    "rate_limter",
     "rate_limiter",
     "per_sec",
     "per_min",


### PR DESCRIPTION
BREAKING CHANGE:
- Removed the misspelled 'rate_limter' alias (correct spelling is 'rate_limiter')
- This is part of v2.0.0 breaking changes
- Users must update all code references from 'rate_limter' to 'rate_limiter'
- Related issue: #38 (https://github.com/ZhuoZhuoCrayon/throttled-py/issues/38)
