### PR TITLE
feat(hook): add hook type validation and exception logging (#134)

### DIFF
--- a/docs/source/advance_usage/hooks.rst
+++ b/docs/source/advance_usage/hooks.rst
@@ -80,7 +80,36 @@ The ``HookContext`` is an immutable dataclass containing information about the r
    ``HookContext`` does not include the result. The result is obtained by calling ``call_next()``.
 
 
-4) Creating Custom Hooks
+4) Hook Type Validation
+=======================
+
+``Throttled`` validates hook types at initialization. Sync ``Throttled`` only accepts ``Hook`` instances,
+and async ``Throttled`` only accepts ``AsyncHook`` instances. Passing an invalid type raises ``TypeError``:
+
+.. code-block:: python
+
+   from throttled import Throttled, Hook, per_sec
+   from throttled.asyncio import Throttled as AsyncThrottled
+   from throttled.asyncio.hooks import Hook as AsyncHook
+
+   # ✅ Correct: sync Hook with sync Throttled
+   Throttled(key="/api", quota=per_sec(10), hooks=[MySyncHook()])
+
+   # ✅ Correct: async Hook with async Throttled
+   AsyncThrottled(key="/api", quota=per_sec(10), hooks=[MyAsyncHook()])
+
+   # ❌ TypeError: async Hook with sync Throttled
+   Throttled(key="/api", quota=per_sec(10), hooks=[MyAsyncHook()])
+
+   # ❌ TypeError: non-hook object
+   Throttled(key="/api", quota=per_sec(10), hooks=["not a hook"])
+
+.. note::
+
+   Hooks are stored as a ``tuple`` internally for immutability after construction.
+
+
+5) Creating Custom Hooks
 ========================
 
 To create a custom hook, inherit from ``Hook`` and implement the ``on_limit`` method:
@@ -113,7 +142,7 @@ Best Practices
               result = call_next()
               return result
 
-2. **Handle exceptions gracefully**: If your hook raises an exception, it will be caught and the hook is skipped entirely - the chain continues by calling the next hook directly. To ensure your hook doesn't get skipped, wrap risky operations in try/except:
+2. **Handle exceptions gracefully**: If your hook raises an exception, it will be caught and the hook is skipped entirely - the chain continues by calling the next hook directly. The exception is logged via ``logger.exception()`` using per-module loggers (``throttled.hooks`` for sync, ``throttled.asyncio.hooks`` for async), so you can capture hook failures through standard Python logging configuration. To ensure your hook doesn't get skipped, wrap risky operations in try/except:
 
    .. code-block:: python
 
@@ -169,7 +198,7 @@ Best Practices
       )
 
 
-5) Built-in Hooks
+6) Built-in Hooks
 =================
 
 throttled-py provides the following built-in hooks:

--- a/tests/asyncio/test_hooks.py
+++ b/tests/asyncio/test_hooks.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Awaitable, Callable
 
 import pytest
@@ -5,9 +6,12 @@ from throttled import (
     HookContext,
     RateLimiterType,
     RateLimitResult,
+    per_sec,
 )
+from throttled.asyncio import Throttled as AsyncThrottled
 from throttled.asyncio.hooks import Hook, build_hook_chain
 from throttled.constants import StoreType
+from throttled.hooks import Hook as SyncHook
 
 
 @pytest.fixture
@@ -144,6 +148,33 @@ class TestBuildHookChain:
         ]
 
     @classmethod
+    async def test_on_limit__exception_logs_error(
+        cls,
+        hook_context: HookContext,
+        rate_limit_result: RateLimitResult,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Hook exception should be logged with logger.exception."""
+
+        class FailingHook(Hook):
+            async def on_limit(self, *args, **kwargs) -> RateLimitResult:  # noqa: PLR6301
+                raise RuntimeError("Hook failed!")
+
+        async def do_limit() -> RateLimitResult:
+            return rate_limit_result
+
+        chain: Callable[[], Awaitable[RateLimitResult]] = build_hook_chain(
+            [FailingHook()], do_limit, hook_context
+        )
+        with caplog.at_level(logging.ERROR, logger="throttled.asyncio.hooks"):
+            await chain()
+
+        assert len(caplog.records) == 1
+        assert "Hook" in caplog.records[0].message
+        assert "raised during on_limit" in caplog.records[0].message
+        assert caplog.records[0].exc_info is not None
+
+    @classmethod
     async def test_on_limit__multi_hooks(
         cls, hook_context: HookContext, rate_limit_result: RateLimitResult
     ) -> None:
@@ -247,3 +278,55 @@ class TestBuildHookChain:
         )
         with pytest.raises(RuntimeError, match="store connection failed"):
             await chain()
+
+
+class _AsyncNoopHook(Hook):
+    async def on_limit(  # noqa: PLR6301
+        self,
+        call_next: Callable[[], Awaitable[RateLimitResult]],
+        context,  # noqa: ANN001
+    ) -> RateLimitResult:
+        return await call_next()
+
+
+class _SyncNoopHook(SyncHook):
+    def on_limit(  # noqa: PLR6301
+        self,
+        call_next: Callable[[], RateLimitResult],
+        context,  # noqa: ANN001
+    ) -> RateLimitResult:
+        return call_next()
+
+
+class _NotAHook:
+    pass
+
+
+class TestHookTypeValidation:
+    @classmethod
+    def test_validate_hooks__rejects_non_hook(cls) -> None:
+        with pytest.raises(TypeError):
+            AsyncThrottled(key="k", quota=per_sec(1), hooks=[_NotAHook()])
+
+    @classmethod
+    def test_validate_hooks__rejects_sync_hook(cls) -> None:
+        with pytest.raises(TypeError):
+            AsyncThrottled(key="k", quota=per_sec(1), hooks=[_SyncNoopHook()])
+
+
+class TestHookContainerBehavior:
+    @classmethod
+    def test_validate_hooks__stores_as_tuple_from_list(cls) -> None:
+        hooks = [_AsyncNoopHook(), _AsyncNoopHook()]
+        throttle = AsyncThrottled(key="k", quota=per_sec(1), hooks=hooks)
+
+        assert isinstance(throttle._hooks, tuple)
+        assert throttle._hooks == tuple(hooks)
+
+    @classmethod
+    def test_validate_hooks__stores_as_tuple_from_tuple(cls) -> None:
+        hooks = (_AsyncNoopHook(), _AsyncNoopHook())
+        throttle = AsyncThrottled(key="k", quota=per_sec(1), hooks=hooks)
+
+        assert isinstance(throttle._hooks, tuple)
+        assert throttle._hooks == hooks

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,4 +1,5 @@
-from collections.abc import Callable
+import logging
+from collections.abc import Awaitable, Callable
 from dataclasses import FrozenInstanceError
 
 import pytest
@@ -6,7 +7,10 @@ from throttled import (
     HookContext,
     RateLimiterType,
     RateLimitResult,
+    Throttled,
+    per_sec,
 )
+from throttled.asyncio.hooks import Hook as AsyncHook
 from throttled.constants import StoreType
 from throttled.hooks import Hook, build_hook_chain
 
@@ -154,6 +158,33 @@ class TestBuildHookChain:
         ]
 
     @classmethod
+    def test_on_limit__exception_logs_error(
+        cls,
+        hook_context: HookContext,
+        rate_limit_result: RateLimitResult,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Hook exception should be logged with logger.exception."""
+
+        class FailingHook(Hook):
+            def on_limit(self, *args, **kwargs) -> RateLimitResult:  # noqa: PLR6301
+                raise RuntimeError("Hook failed!")
+
+        def do_limit() -> RateLimitResult:
+            return rate_limit_result
+
+        chain: Callable[[], RateLimitResult] = build_hook_chain(
+            [FailingHook()], do_limit, hook_context
+        )
+        with caplog.at_level(logging.ERROR, logger="throttled.hooks"):
+            chain()
+
+        assert len(caplog.records) == 1
+        assert "Hook" in caplog.records[0].message
+        assert "raised during on_limit" in caplog.records[0].message
+        assert caplog.records[0].exc_info is not None
+
+    @classmethod
     def test_on_limit__multi_hooks(
         cls, hook_context: HookContext, rate_limit_result: RateLimitResult
     ) -> None:
@@ -257,3 +288,55 @@ class TestBuildHookChain:
         )
         with pytest.raises(RuntimeError, match="store connection failed"):
             chain()
+
+
+class _SyncNoopHook(Hook):
+    def on_limit(  # noqa: PLR6301
+        self,
+        call_next: Callable[[], RateLimitResult],
+        context,  # noqa: ANN001
+    ) -> RateLimitResult:
+        return call_next()
+
+
+class _AsyncNoopHook(AsyncHook):
+    async def on_limit(  # noqa: PLR6301
+        self,
+        call_next: Callable[[], Awaitable[RateLimitResult]],
+        context,  # noqa: ANN001
+    ) -> RateLimitResult:
+        return await call_next()
+
+
+class _NotAHook:
+    pass
+
+
+class TestHookTypeValidation:
+    @classmethod
+    def test_validate_hooks__rejects_non_hook(cls) -> None:
+        with pytest.raises(TypeError):
+            Throttled(key="k", quota=per_sec(1), hooks=[_NotAHook()])
+
+    @classmethod
+    def test_validate_hooks__rejects_async_hook(cls) -> None:
+        with pytest.raises(TypeError):
+            Throttled(key="k", quota=per_sec(1), hooks=[_AsyncNoopHook()])
+
+
+class TestHookContainerBehavior:
+    @classmethod
+    def test_validate_hooks__stores_as_tuple_from_list(cls) -> None:
+        hooks = [_SyncNoopHook(), _SyncNoopHook()]
+        throttle = Throttled(key="k", quota=per_sec(1), hooks=hooks)
+
+        assert isinstance(throttle._hooks, tuple)
+        assert throttle._hooks == tuple(hooks)
+
+    @classmethod
+    def test_validate_hooks__stores_as_tuple_from_tuple(cls) -> None:
+        hooks = (_SyncNoopHook(), _SyncNoopHook())
+        throttle = Throttled(key="k", quota=per_sec(1), hooks=hooks)
+
+        assert isinstance(throttle._hooks, tuple)
+        assert throttle._hooks == hooks

--- a/throttled/asyncio/hooks.py
+++ b/throttled/asyncio/hooks.py
@@ -1,10 +1,13 @@
 """Async hook system for throttled-py."""
 
 import abc
-from collections.abc import Awaitable, Callable
+import logging
+from collections.abc import Awaitable, Callable, Sequence
 from typing import TYPE_CHECKING
 
 from ..hooks import HookContext
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from ..rate_limiter import RateLimitResult
@@ -48,7 +51,7 @@ class Hook(abc.ABC):
 
 
 def build_hook_chain(
-    hooks: list[Hook],
+    hooks: Sequence[Hook],
     do_limit: Callable[[], Awaitable["RateLimitResult"]],
     context: HookContext,
 ) -> Callable[[], Awaitable["RateLimitResult"]]:
@@ -59,7 +62,7 @@ def build_hook_chain(
 
     Exceptions raised in hooks are caught and the chain continues.
 
-    :param hooks: List of async hooks to chain.
+    :param hooks: Sequence of async hooks to chain.
     :param do_limit: The actual async rate limit function to be wrapped.
     :param context: The hook context containing rate limit metadata.
     :return: A callable that executes the async hook chain.
@@ -102,7 +105,7 @@ def build_hook_chain(
                 try:
                     return await h.on_limit(tracked_next, context)
                 except Exception:
-                    # TODO - Logging strategy should be developed
+                    logger.exception("Hook %r raised during on_limit", h)
                     if next_called:
                         return next_result
                     return await next_fn()

--- a/throttled/asyncio/throttled.py
+++ b/throttled/asyncio/throttled.py
@@ -9,13 +9,15 @@ from ..hooks import HookContext
 from ..throttled import BaseThrottledMixin
 from ..types import KeyT, StoreP
 from ..utils import now_mono_f
-from .hooks import build_hook_chain
+from .hooks import Hook, build_hook_chain
 from .rate_limiter import RateLimiterRegistry, RateLimitResult, RateLimitState
 from .store import MemoryStore
 
 
 class BaseThrottled(BaseThrottledMixin, abc.ABC):
     """Abstract class for all throttled classes."""
+
+    _ALLOWED_HOOK_TYPES = (Hook,)
 
     @abc.abstractmethod
     async def __aenter__(self) -> RateLimitResult:

--- a/throttled/hooks.py
+++ b/throttled/hooks.py
@@ -1,9 +1,12 @@
 """Hook system for throttled-py."""
 
 import abc
-from collections.abc import Callable
+import logging
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+
+logger: logging.Logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .rate_limiter import RateLimitResult
@@ -68,7 +71,7 @@ class Hook(abc.ABC):
 
 
 def build_hook_chain(
-    hooks: list[Hook],
+    hooks: Sequence[Hook],
     do_limit: Callable[[], "RateLimitResult"],
     context: HookContext,
 ) -> Callable[[], "RateLimitResult"]:
@@ -79,7 +82,7 @@ def build_hook_chain(
 
     Exceptions raised in hooks are caught and the chain continues.
 
-    :param hooks: List of hooks to chain.
+    :param hooks: Sequence of hooks to chain.
     :param do_limit: The actual rate limit function to be wrapped.
     :param context: The hook context containing rate limit metadata.
     :return: A callable that executes the hook chain.
@@ -122,7 +125,7 @@ def build_hook_chain(
                 try:
                     return h.on_limit(tracked_next, context)
                 except Exception:
-                    # TODO - Logging strategy should be developed
+                    logger.exception("Hook %r raised during on_limit", h)
                     if next_called:
                         return next_result
                     return next_fn()

--- a/throttled/throttled.py
+++ b/throttled/throttled.py
@@ -1,7 +1,7 @@
 import abc
 import threading
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import wraps
 from types import TracebackType
 
@@ -42,6 +42,7 @@ class BaseThrottledMixin:
     )
 
     _REGISTRY_CLASS: type[RateLimiterRegistry] = None
+    _ALLOWED_HOOK_TYPES: tuple[type[HookP], ...] = ()
 
     # Default store for the rate limiter.
     # By default, the global shared MemoryStore is used, when no store is specified.
@@ -62,7 +63,7 @@ class BaseThrottledMixin:
         quota: Quota | None = None,
         store: StoreP | None = None,
         cost: int = 1,
-        hooks: list[HookP] | None = None,
+        hooks: Sequence[HookP] | None = None,
     ):
         """Initializes the Throttled class.
 
@@ -81,7 +82,7 @@ class BaseThrottledMixin:
         :type store: :class:`throttled.store.BaseStore`
         :param cost: The cost of each request in terms of how much of the rate limit
             quota it consumes, default: 1.
-        :param hooks: A list of hooks invoked by the middleware before and/or after
+        :param hooks: A sequence of hooks invoked by the middleware before and/or after
             each ``limit()`` operation, including any internal retries.
         """
         # TODO Support key prefix.
@@ -102,7 +103,7 @@ class BaseThrottledMixin:
 
         self._lock: LockP = self._get_lock()
         self._limiter: RateLimiterP | None = None
-        self._hooks: list[HookP] = list(hooks) if hooks else []
+        self._hooks: tuple[HookP, ...] = self._validate_hooks(hooks)
 
         self._validate_cost(cost)
         self._cost: int = cost
@@ -124,6 +125,18 @@ class BaseThrottledMixin:
 
             self._limiter = self._limiter_cls(self._quota, self._store)
             return self._limiter
+
+    def _validate_hooks(self, hooks: Sequence[HookP] | None) -> tuple[HookP, ...]:
+        """Validate that all hooks are of the expected type and return as tuple."""
+        if not hooks:
+            return ()
+        for hook in hooks:
+            if not isinstance(hook, self._ALLOWED_HOOK_TYPES):
+                expected = ", ".join(t.__name__ for t in self._ALLOWED_HOOK_TYPES)
+                raise TypeError(
+                    f"Invalid hook type: {type(hook).__name__}. Expected: {expected}"
+                )
+        return tuple(hooks)
 
     @classmethod
     def _validate_cost(cls, cost: int) -> None:
@@ -197,6 +210,8 @@ class BaseThrottledMixin:
 
 class BaseThrottled(BaseThrottledMixin, abc.ABC):
     """Abstract class for all throttled classes."""
+
+    _ALLOWED_HOOK_TYPES = (Hook,)
 
     @abc.abstractmethod
     def __enter__(self) -> RateLimitResult:


### PR DESCRIPTION
<!--
Thanks for submitting a PR, your contribution is really appreciated!

Here is a quick checklist that should be present in PRs.
Please see the contributing guide for details: [CONTRIBUTING.md](../CONTRIBUTING.md)
-->

## Summary

- **Hook type validation at init**:
    - sync `Throttled` only accepts `Hook`, async `Throttled` only accepts `AsyncHook`.
      Passes invalid type → `TypeError`. Uses `_ALLOWED_HOOK_TYPES` class attribute to distinguish sync/async.
    - Inheritance check is intentional; `call_next` return type differs between sync and async,
      so duck typing cannot tell them apart, causing silent failures.
- **Immutable hook storage**:
    - hooks stored as `tuple` instead of `list`.
- **Exception logging in hook chain**:
    - added per-module loggers (`throttled.hooks`, `throttled.asyncio.hooks`) and replaced silent `except Exception`
      with `logger.exception()`[^1].
- **Documentation**:
    - added "Hook Type Validation" section and updated exception handling description
      in `docs/source/advance_usage/hooks.rst`.

## Checklists

- [x] Include documentation when adding new features.
- [x] Include new tests or update existing tests when applicable.
- [x] Read and follow the [Contributing Guide](../CONTRIBUTING.md).
- [x] Allow maintainers to push and squash when merging my commits.
  Please uncheck this if you prefer to squash the commits yourself.

<!--
If this change fixes an issue, please add text like `closes #xxx` below
(where xxx is the issue number).
-->

Closes #134

[^1]: No `NullHandler` used. Python 3.2+ prints unhandled logs to `stderr` by default. This is better than silence, since silent hook failures were the original problem (#134).