### PR TITLE
docs: add AGENTS guidance and branch naming rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,4 +12,5 @@ working in this repository.
 - Create branches from `main`.
 - Use the naming format documented in `CONTRIBUTING.md`:
   `<type>/<yymmdd>_<topic>`.
+- Follow the commit conventions in `CONTRIBUTING.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# throttled-py Agent Instructions
+
+This file defines the minimum rule order for AI agents and contributors
+working in this repository.
+
+## 0x01 Canonical Rules
+
+- For contribution workflow and standards, follow `CONTRIBUTING.md`.
+
+## 0x02 Branch and Commit Guardrails
+
+- Create branches from `main`.
+- Use the naming format documented in `CONTRIBUTING.md`:
+  `<type>/<yymmdd>_<topic>`.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ This guide will help you get started and ensure a smooth review process. If anyt
 
 - [Getting Started](#getting-started)
 - [Development Setup](#development-setup)
+- [Branch Naming](#branch-naming)
 - [Code Style](#code-style)
 - [Testing Guidelines](#testing-guidelines)
 - [Documentation](#documentation)
@@ -17,10 +18,11 @@ This guide will help you get started and ensure a smooth review process. If anyt
 ## Getting Started
 
 1. Fork the repository and clone your fork.
-2. Create a branch from `main` for your changes.
-3. Follow the [Development Setup](#development-setup) to configure your environment.
-4. Make your changes, following the guidelines below.
-5. Submit a pull request.
+2. Read `AGENTS.md`, then read this `CONTRIBUTING.md`.
+3. Create a branch from `main` for your changes.
+4. Follow the [Development Setup](#development-setup) to configure your environment.
+5. Make your changes, following the guidelines below.
+6. Submit a pull request.
 
 ## Development Setup
 
@@ -62,6 +64,30 @@ uv run prek run --all-files
 ```
 
 > **Important**: Please run prek locally before pushing. CI will block merging if the Code Quality check fails.
+
+## Branch Naming
+
+Create branches from `main` and use the format below:
+
+```text
+<type>/<yymmdd>_<topic>
+```
+
+Where:
+
+- `type`: one of `feat`, `fix`, `docs`, `ci`, `refactor`, `test`, `chore`,
+  `perf`, `build`
+- `yymmdd`: date in two-digit year format (for example: `260405`)
+- `topic`: short, lowercase identifier using letters, numbers, and `_`
+
+Examples:
+
+```bash
+git checkout main
+git pull --ff-only upstream main
+git checkout -b feat/260405_quota_parser_dsl
+git checkout -b docs/260405_contributing_branch_rules
+```
 
 ## Code Style
 


### PR DESCRIPTION
## Summary

- add project-level `AGENTS.md` to clarify contributor/agent guardrails
- make `CONTRIBUTING.md` explicitly document branch naming format
- add branch naming examples and update Getting Started flow

## Validation

- run `uv run prek run --files AGENTS.md CONTRIBUTING.md`
