### PR TITLE
docs: align README python badge and extras with pyproject

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,17 +220,17 @@ CI checks test coverage via [Codecov](https://about.codecov.io/). Please make su
 You can check coverage locally:
 
 ```bash
-uv run pytest --cov=throttled --cov-report=term-missing tests/
+uv run pytest -n auto --cov=throttled --cov-report=term-missing tests/
 ```
 
 ### Running Tests
 
 ```bash
 # Run all tests
-uv run pytest tests/ -x
+uv run pytest -n auto tests/ -x
 
 # Run a specific test file
-uv run pytest tests/test_hooks.py -v
+uv run pytest -n auto tests/test_hooks.py -v
 ```
 
 ## Documentation
@@ -330,7 +330,7 @@ All of the following must pass before merging:
 Before submitting your pull request, please verify the following:
 
 - [ ] `uv run prek run --all-files` passes locally
-- [ ] `uv run pytest tests/ -x` passes locally
+- [ ] `uv run pytest -n auto tests/ -x` passes locally
 - [ ] Type annotations added to all variables
 - [ ] Docstrings use reStructuredText style (`:param:`, `:return:`)
 - [ ] Tests are class-based with `@classmethod`

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
-        <img src="https://img.shields.io/badge/python-%3E%3D3.8-green?logo=python" alt="Python">
+        <img src="https://img.shields.io/badge/python-%3E%3D3.10-green?logo=python" alt="Python">
     </a>
      <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
         <img src="https://codecov.io/gh/ZhuoZhuoCrayon/throttled-py/graph/badge.svg" alt="Coverage Status">
@@ -57,14 +57,16 @@ To enable additional features, install optional dependencies as follows (multipl
 ```shell
 $ pip install "throttled-py[redis]"
 
-$ pip install "throttled-py[redis,in-memory]"
+$ pip install "throttled-py[memory]"
+
+$ pip install "throttled-py[redis,otel]"
 ```
 
 | Extra       | Description                       |
 |-------------|-----------------------------------|
-| `all`       | Install all extras.               |
-| `in-memory` | Use In-Memory as storage backend. |
+| `memory`    | Use In-Memory as storage backend. |
 | `redis`     | Use Redis as storage backend.     |
+| `otel`      | Enable OpenTelemetry hook support. |
 
 
 ## 🎨 Quick Start

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@
 $ pip install throttled-py
 ```
 
-> Note: `v3.x` requires Python `>=3.10`. If you are using Python `3.8/3.9`, install `<3.0.0`.
+> Note: `v3.x` requires Python `>=3.10`. If you are using Python `3.8/3.9`, install `throttled-py<3.0.0`.
 
 ### 1) Optional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
-        <img src="https://img.shields.io/badge/python-%3E%3D3.10-green?logo=python" alt="Python">
+        <img src="https://img.shields.io/badge/python-%3E%3D3.8-green?logo=python" alt="Python">
     </a>
      <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
         <img src="https://codecov.io/gh/ZhuoZhuoCrayon/throttled-py/graph/badge.svg" alt="Coverage Status">
@@ -48,6 +48,8 @@
 $ pip install throttled-py
 ```
 
+> Note: `v3.x` requires Python `>=3.10`. If you are using Python `3.8/3.9`, install `<3.0.0`.
+
 ### 1) Optional Dependencies
 
 Starting from [v2.0.0](https://github.com/ZhuoZhuoCrayon/throttled-py/releases/tag/v2.0.0), only core dependencies are installed by default.
@@ -57,14 +59,14 @@ To enable additional features, install optional dependencies as follows (multipl
 ```shell
 $ pip install "throttled-py[redis]"
 
-$ pip install "throttled-py[memory]"
+$ pip install "throttled-py[otel]"
 
 $ pip install "throttled-py[redis,otel]"
 ```
 
 | Extra       | Description                       |
 |-------------|-----------------------------------|
-| `memory`    | Use In-Memory as storage backend. |
+| `memory`    | In-Memory backend is available by default (`memory` extra installs no additional dependencies). |
 | `redis`     | Use Redis as storage backend.     |
 | `otel`      | Enable OpenTelemetry hook support. |
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -48,7 +48,7 @@
 $ pip install throttled-py
 ```
 
-> 说明：`v3.x` 要求 Python `>=3.10`。如果你使用的是 Python `3.8/3.9`，请安装 `<3.0.0` 版本。
+> 说明：`v3.x` 要求 Python `>=3.10`。如果你使用的是 Python `3.8/3.9`，请安装 `throttled-py<3.0.0`。
 
 ### 1）额外依赖
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
-        <img src="https://img.shields.io/badge/python-%3E%3D3.8-green?logo=python" alt="Python">
+        <img src="https://img.shields.io/badge/python-%3E%3D3.10-green?logo=python" alt="Python">
     </a>
      <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
         <img src="https://codecov.io/gh/ZhuoZhuoCrayon/throttled-py/graph/badge.svg" alt="Coverage Status">
@@ -57,16 +57,18 @@ $ pip install throttled-py
 ```shell
 $ pip install "throttled-py[redis]"
 
-$ pip install "throttled-py[redis,in-memory]"
+$ pip install "throttled-py[memory]"
+
+$ pip install "throttled-py[redis,otel]"
 ```
 
 可选依赖项说明：
 
 | 附加依赖项       | 描述               |
 |-------------|------------------|
-| `all`       | 安装所有扩展依赖。        | 
-| `in-memory` | 使用内存作为存储后端。      |
+| `memory`    | 使用内存作为存储后端。      |
 | `redis`     | 使用 Redis 作为存储后端。 |
+| `otel`      | 启用 OpenTelemetry Hook 支持。 |
 
 
 ## 🎨 快速开始

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -5,7 +5,7 @@
 
 <p align="center">
     <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
-        <img src="https://img.shields.io/badge/python-%3E%3D3.10-green?logo=python" alt="Python">
+        <img src="https://img.shields.io/badge/python-%3E%3D3.8-green?logo=python" alt="Python">
     </a>
      <a href="https://github.com/ZhuoZhuoCrayon/throttled-py">
         <img src="https://codecov.io/gh/ZhuoZhuoCrayon/throttled-py/graph/badge.svg" alt="Coverage Status">
@@ -48,6 +48,8 @@
 $ pip install throttled-py
 ```
 
+> 说明：`v3.x` 要求 Python `>=3.10`。如果你使用的是 Python `3.8/3.9`，请安装 `<3.0.0` 版本。
+
 ### 1）额外依赖
 
 自 [v2.0.0](https://github.com/ZhuoZhuoCrayon/throttled-py/releases/tag/v2.0.0) 版本起，默认安装仅包含核心功能依赖。
@@ -57,7 +59,7 @@ $ pip install throttled-py
 ```shell
 $ pip install "throttled-py[redis]"
 
-$ pip install "throttled-py[memory]"
+$ pip install "throttled-py[otel]"
 
 $ pip install "throttled-py[redis,otel]"
 ```
@@ -66,7 +68,7 @@ $ pip install "throttled-py[redis,otel]"
 
 | 附加依赖项       | 描述               |
 |-------------|------------------|
-| `memory`    | 使用内存作为存储后端。      |
+| `memory`    | 内存后端默认可用（`memory` extra 不会额外安装依赖）。 |
 | `redis`     | 使用 Redis 作为存储后端。 |
 | `otel`      | 启用 OpenTelemetry Hook 支持。 |
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -8,12 +8,17 @@ Install the package with pip:
 
     $ pip install throttled-py
 
+.. note::
+
+    ``v3.x`` requires Python ``>=3.10``.
+    If you are using Python ``3.8/3.9``, install ``<3.0.0``.
+
 
 1) Optional Dependencies
 =========================
 
 Starting from `v2.0.0 <https://github.com/ZhuoZhuoCrayon/throttled-py/releases/tag/v2.0.0>`_,
-only core dependencies(``in-memory``) are installed by default.
+only core dependencies are installed by default.
 
 To enable additional features, install optional dependencies as follows (multiple extras can
 be comma-separated):
@@ -21,21 +26,19 @@ be comma-separated):
 .. code-block:: shell
 
     $ pip install "throttled-py[redis]"
-    $ pip install "throttled-py[redis,in-memory]"
+    $ pip install "throttled-py[otel]"
+    $ pip install "throttled-py[redis,otel]"
 
 
 2) Extras
 ==========
 
-+--------------+--------------------------------------+
-| Extra        | Description                          |
-+==============+======================================+
-| ``all``      | Install all extras.                  |
-+--------------+--------------------------------------+
-| ``in-memory``| Use In-Memory as storage backend.    |
-+--------------+--------------------------------------+
-| ``redis``    | Use Redis as storage backend.        |
-+--------------+--------------------------------------+
-| ``otel``     | OpenTelemetry metrics integration.   |
-+--------------+--------------------------------------+
-
++------------+--------------------------------------------------------------------------------------+
+| Extra      | Description                                                                          |
++============+======================================================================================+
+| ``memory`` | In-Memory backend is available by default (``memory`` extra installs no dependencies). |
++------------+--------------------------------------------------------------------------------------+
+| ``redis``  | Use Redis as storage backend.                                                        |
++------------+--------------------------------------------------------------------------------------+
+| ``otel``   | OpenTelemetry metrics integration.                                                   |
++------------+--------------------------------------------------------------------------------------+

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -11,7 +11,7 @@ Install the package with pip:
 .. note::
 
     ``v3.x`` requires Python ``>=3.10``.
-    If you are using Python ``3.8/3.9``, install ``<3.0.0``.
+    If you are using Python ``3.8/3.9``, install ``throttled-py<3.0.0``.
 
 
 1) Optional Dependencies


### PR DESCRIPTION
## Summary

Fix README metadata drift so installation instructions match package configuration.

## Changes

- Update Python badge in `README.md` and `README_ZH.md` from `>=3.8` to `>=3.10` (matches `pyproject.toml`).
- Update optional dependency installation examples:
  - replace `in-memory` with `memory`
  - remove non-existent `all` extra from docs table
  - add `otel` extra to docs table and installation examples

## Why

`pyproject.toml` is the source of truth:

- `requires-python = ">=3.10"`
- optional dependencies: `memory`, `redis`, `otel`

Before this PR, README examples/tables used `in-memory` and `all`, which can mislead users during installation.

## Verification

- Manual consistency check against `pyproject.toml`
- Pre-commit hooks on commit passed for changed files
