### PR TITLE
docs: remove squash-before-push requirement from CONTRIBUTING.md (#146)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ uv run prek install
 Verify the installation:
 
 ```bash
-# Should list: check-merge-conflict, ruff, ruff-format
+# Should list: check-merge-conflict, ruff, ruff-format, mypy-strict
 uv run prek list
 ```
 
@@ -335,26 +335,24 @@ git rebase origin/main
 
 Do not use merge commits to sync with `main` (for example, `git merge main`).
 
-### 2. Squash and Push
+### 2. Push Your Changes
 
-Before pushing, please squash your commits into a single commit with a valid [Conventional Commits](#commit-conventions) message. CI validates the commit message via commitlint — squashing helps it pass on the first push.
+Push your branch normally. You do not need to squash commits before pushing; the maintainer will squash-merge the PR when it is ready.
 
 ```bash
-# Squash N commits into one
-git rebase -i HEAD~N
+git push origin <your-branch>
+```
 
-# Verify the message format before pushing
-git log --oneline -1
-# Should show: <type>: <description> (#<issue-number>)
+If you rebased onto `main`, you may need to force-push:
 
-# Rebase branch update requires force push
+```bash
 git push --force-with-lease origin <your-branch>
 ```
 
 ### 3. Respond to Reviews
 
 - Please address all review comments before requesting re-review.
-- Rebase and squash again when the maintainer asks you to sync with `main`.
+- Rebase onto `main` when the maintainer asks you to sync.
 - Please re-run prek after making changes to ensure lint checks still pass.
 
 ### 4. CI Checks
@@ -383,4 +381,4 @@ Before submitting your pull request, please verify the following:
 - [ ] No duplicate fixtures
 - [ ] Public API changes include README (EN + ZH), docs, and examples updates
 - [ ] Commit message follows Conventional Commits (`<type>: <description> (#issue)`)
-- [ ] Commits are squashed and rebased onto `main`
+- [ ] Branch is rebased onto `main`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -370,8 +370,13 @@ All of the following must pass before merging:
 
 Before submitting your pull request, please verify the following:
 
+### Local Checks
+
 - [ ] `uv run prek run --all-files` passes locally
 - [ ] `uv run pytest -n auto tests/ -x` passes locally
+
+### Code and Tests
+
 - [ ] Type annotations added to all variables
 - [ ] Docstrings use reStructuredText style (`:param:`, `:return:`)
 - [ ] Tests are class-based with `@classmethod`
@@ -379,6 +384,12 @@ Before submitting your pull request, please verify the following:
 - [ ] Unit tests follow test mirroring path rules (`throttled/<package>/<module>.py` -> `tests/<package>/test_<module>.py`)
 - [ ] No empty files or unused code
 - [ ] No duplicate fixtures
+
+### Documentation
+
 - [ ] Public API changes include README (EN + ZH), docs, and examples updates
+
+### Branch and Commit
+
 - [ ] Commit message follows Conventional Commits (`<type>: <description> (#issue)`)
 - [ ] Branch is rebased onto `main`


### PR DESCRIPTION
## Summary

- Remove the "squash before push" rule from the Pull Request Process section
- Update PR Checklist: "Commits are squashed and rebased onto main" → "Branch is rebased onto main"
- Add `mypy-strict` to prek list (missed in #142)
- Organize PR Checklist into subsections for readability

See #146 for full discussion. The squash-before-push rule was added based on feedback from PR #125, but it was a situational request that got generalized into a blanket rule. Since the repo already uses squash merge, asking contributors to squash locally is redundant.

## Checklists

- [ ] Include documentation when adding new features.
- [ ] Include new tests or update existing tests when applicable.
- [x] Read and follow the [Contributing Guide](../CONTRIBUTING.md).
- [x] Allow maintainers to push and squash when merging my commits.

Closes #146