### PR TITLE
fix: prevent GCRA from rejecting an unseen key's first request due to float rounding

### DIFF
--- a/tests/asyncio/rate_limiter/test_gcra.py
+++ b/tests/asyncio/rate_limiter/test_gcra.py
@@ -72,9 +72,6 @@ class TestGCRARateLimiter:
                 task=_task, batch=requests_num
             )
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     async def test_limit__fresh_key_first_request_allowed(cls) -> None:
         """The first request for an unseen key passes when burst equals cost.
@@ -93,9 +90,6 @@ class TestGCRARateLimiter:
             assert not result.limited, f"first request rejected at now={now!r}"
             assert result.state.remaining == 0
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     async def test_limit__fresh_key_first_request_allowed_redis(
         cls, redis_store: RedisStore
@@ -111,9 +105,6 @@ class TestGCRARateLimiter:
             assert not result.limited, f"first request rejected at time={now!r}"
             assert result.state.remaining == 0
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     async def test_peek__fresh_key_reports_full_burst(cls) -> None:
         """Peek on an unseen key reports the whole burst as remaining.
@@ -133,9 +124,6 @@ class TestGCRARateLimiter:
                 limit=1, remaining=1, reset_after=0, retry_after=0
             ), f"peek misreported at now={now!r}"
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     async def test_peek__fresh_key_reports_full_burst_redis(
         cls, redis_store: RedisStore

--- a/tests/asyncio/rate_limiter/test_gcra.py
+++ b/tests/asyncio/rate_limiter/test_gcra.py
@@ -1,22 +1,26 @@
 import asyncio
 from collections.abc import Callable
+from unittest import mock
 
 import pytest
 from throttled.asyncio import (
     BaseRateLimiter,
     BaseStore,
+    MemoryStore,
     Quota,
     RateLimiterRegistry,
     RateLimiterType,
     RateLimitResult,
     RateLimitState,
+    RedisStore,
     per_min,
+    per_sec,
     types,
     utils,
 )
 
 from ...rate_limiter import parametrizes
-from ...rate_limiter.test_gcra import assert_rate_limit_result
+from ...rate_limiter.test_gcra import REDIS_CLOCK_EPOCH, assert_rate_limit_result
 
 
 @pytest.fixture
@@ -67,6 +71,86 @@ class TestGCRARateLimiter:
             results: list[bool] = await benchmark.async_concurrent(
                 task=_task, batch=requests_num
             )
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    async def test_limit__fresh_key_first_request_allowed(cls) -> None:
+        """The first request for an unseen key passes when burst equals cost.
+
+        Deriving allow_at as (now + interval) - interval can round just above
+        now, which rejected unseen keys outright for many clock values - most
+        likely on recently booted machines, where time.monotonic() is small.
+        """
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_min(limit=1, burst=1), MemoryStore())
+        for idx in range(4096):
+            now: float = 30.0 + idx * 0.0173
+            with mock.patch("throttled.utils.now_mono_f", return_value=now):
+                result: RateLimitResult = await rate_limiter.limit(f"key-{idx}")
+            assert not result.limited, f"first request rejected at now={now!r}"
+            assert result.state.remaining == 0
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    async def test_limit__fresh_key_first_request_allowed_redis(
+        cls, redis_store: RedisStore
+    ) -> None:
+        """As the memory variant, but driving the Lua script's clock."""
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_min(limit=1, burst=1), redis_store)
+        for idx in range(4096):
+            now: float = REDIS_CLOCK_EPOCH + 30.0 + idx * 0.0173
+            with mock.patch("time.time", return_value=now):
+                result: RateLimitResult = await rate_limiter.limit(f"key-{idx}")
+            assert not result.limited, f"first request rejected at time={now!r}"
+            assert result.state.remaining == 0
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    async def test_peek__fresh_key_reports_full_burst(cls) -> None:
+        """Peek on an unseen key reports the whole burst as remaining.
+
+        An emission interval without an exact binary representation (1/3s
+        here) used to make the allow_at derivation round against the key,
+        reporting it as limited before it ever made a request.
+        """
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_sec(limit=3, burst=1), MemoryStore())
+        for idx in range(4096):
+            now: float = 30.0 + idx * 0.0173
+            with mock.patch("throttled.utils.now_mono_f", return_value=now):
+                state: RateLimitState = await rate_limiter.peek(f"key-{idx}")
+            assert state == RateLimitState(
+                limit=1, remaining=1, reset_after=0, retry_after=0
+            ), f"peek misreported at now={now!r}"
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    async def test_peek__fresh_key_reports_full_burst_redis(
+        cls, redis_store: RedisStore
+    ) -> None:
+        """As the memory variant, but driving the Lua script's clock."""
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_sec(limit=3, burst=1), redis_store)
+        for idx in range(4096):
+            now: float = REDIS_CLOCK_EPOCH + 30.0 + idx * 0.0173
+            with mock.patch("time.time", return_value=now):
+                state: RateLimitState = await rate_limiter.peek(f"key-{idx}")
+            assert state == RateLimitState(
+                limit=1, remaining=1, reset_after=0, retry_after=0
+            ), f"peek misreported at time={now!r}"
 
     async def test_peek(
         self, rate_limiter_constructor: Callable[[Quota], BaseRateLimiter]

--- a/tests/rate_limiter/test_gcra.py
+++ b/tests/rate_limiter/test_gcra.py
@@ -1,21 +1,32 @@
 import time
 from collections.abc import Callable
+from unittest import mock
 
 import pytest
 from throttled import (
     BaseRateLimiter,
     BaseStore,
+    MemoryStore,
     Quota,
     RateLimiterRegistry,
     RateLimitResult,
     RateLimitState,
+    RedisStore,
     per_min,
+    per_sec,
 )
 from throttled.constants import RateLimiterType
+from throttled.rate_limiter.gcra import (
+    RedisLimitAtomicActionSpec,
+    RedisPeekAtomicActionSpec,
+)
 from throttled.types import TimeLikeValueT
 from throttled.utils import Benchmark, Timer
 
 from . import parametrizes
+
+REDIS_CLOCK_EPOCH: int = 1735660800
+"""The offset the GCRA Lua scripts subtract from the Redis clock."""
 
 
 @pytest.fixture
@@ -73,6 +84,97 @@ class TestGCRARateLimiter:
             results: list[bool] = benchmark.concurrent(
                 task=lambda: rate_limiter.limit("key").limited, batch=requests_num
             )
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    def test_limit__fresh_key_first_request_allowed(cls) -> None:
+        """The first request for an unseen key passes when burst equals cost.
+
+        Deriving allow_at as (now + interval) - interval can round just above
+        now, which rejected unseen keys outright for many clock values - most
+        likely on recently booted machines, where time.monotonic() is small.
+        """
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_min(limit=1, burst=1), MemoryStore())
+        for idx in range(4096):
+            now: float = 30.0 + idx * 0.0173
+            with mock.patch("throttled.utils.now_mono_f", return_value=now):
+                result: RateLimitResult = rate_limiter.limit(f"key-{idx}")
+            assert not result.limited, f"first request rejected at now={now!r}"
+            assert result.state.remaining == 0
+
+    @classmethod
+    def test_redis_clock_epoch__matches_lua_scripts(cls) -> None:
+        """The Redis sweeps below must land just past the scripts' offset, so
+        drift would be a silent loss of coverage.
+        """
+        for scripts in (
+            RedisLimitAtomicActionSpec.SCRIPTS,
+            RedisPeekAtomicActionSpec.SCRIPTS,
+        ):
+            assert f"local jan_1_2025 = {REDIS_CLOCK_EPOCH}" in scripts
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    def test_limit__fresh_key_first_request_allowed_redis(
+        cls, redis_store: RedisStore
+    ) -> None:
+        """As the memory variant, but driving the Lua script's clock."""
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_min(limit=1, burst=1), redis_store)
+        for idx in range(4096):
+            now: float = REDIS_CLOCK_EPOCH + 30.0 + idx * 0.0173
+            with mock.patch("time.time", return_value=now):
+                result: RateLimitResult = rate_limiter.limit(f"key-{idx}")
+            assert not result.limited, f"first request rejected at time={now!r}"
+            assert result.state.remaining == 0
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    def test_peek__fresh_key_reports_full_burst(cls) -> None:
+        """Peek on an unseen key reports the whole burst as remaining.
+
+        An emission interval without an exact binary representation (1/3s
+        here) used to make the allow_at derivation round against the key,
+        reporting it as limited before it ever made a request.
+        """
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_sec(limit=3, burst=1), MemoryStore())
+        for idx in range(4096):
+            now: float = 30.0 + idx * 0.0173
+            with mock.patch("throttled.utils.now_mono_f", return_value=now):
+                state: RateLimitState = rate_limiter.peek(f"key-{idx}")
+            assert state == RateLimitState(
+                limit=1, remaining=1, reset_after=0, retry_after=0
+            ), f"peek misreported at now={now!r}"
+
+    @pytest.mark.xfail(
+        reason="the allow_at derivation rounds against unseen keys", strict=True
+    )
+    @classmethod
+    def test_peek__fresh_key_reports_full_burst_redis(
+        cls, redis_store: RedisStore
+    ) -> None:
+        """As the memory variant, but driving the Lua script's clock."""
+        rate_limiter: BaseRateLimiter = RateLimiterRegistry.get(
+            RateLimiterType.GCRA.value
+        )(per_sec(limit=3, burst=1), redis_store)
+        for idx in range(4096):
+            now: float = REDIS_CLOCK_EPOCH + 30.0 + idx * 0.0173
+            with mock.patch("time.time", return_value=now):
+                state: RateLimitState = rate_limiter.peek(f"key-{idx}")
+            assert state == RateLimitState(
+                limit=1, remaining=1, reset_after=0, retry_after=0
+            ), f"peek misreported at time={now!r}"
 
     def test_peek(self, rate_limiter_constructor: Callable[[Quota], BaseRateLimiter]):
         key: str = "key"

--- a/tests/rate_limiter/test_gcra.py
+++ b/tests/rate_limiter/test_gcra.py
@@ -85,9 +85,6 @@ class TestGCRARateLimiter:
                 task=lambda: rate_limiter.limit("key").limited, batch=requests_num
             )
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     def test_limit__fresh_key_first_request_allowed(cls) -> None:
         """The first request for an unseen key passes when burst equals cost.
@@ -117,9 +114,6 @@ class TestGCRARateLimiter:
         ):
             assert f"local jan_1_2025 = {REDIS_CLOCK_EPOCH}" in scripts
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     def test_limit__fresh_key_first_request_allowed_redis(
         cls, redis_store: RedisStore
@@ -135,9 +129,6 @@ class TestGCRARateLimiter:
             assert not result.limited, f"first request rejected at time={now!r}"
             assert result.state.remaining == 0
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     def test_peek__fresh_key_reports_full_burst(cls) -> None:
         """Peek on an unseen key reports the whole burst as remaining.
@@ -157,9 +148,6 @@ class TestGCRARateLimiter:
                 limit=1, remaining=1, reset_after=0, retry_after=0
             ), f"peek misreported at now={now!r}"
 
-    @pytest.mark.xfail(
-        reason="the allow_at derivation rounds against unseen keys", strict=True
-    )
     @classmethod
     def test_peek__fresh_key_reports_full_burst_redis(
         cls, redis_store: RedisStore

--- a/throttled/rate_limiter/gcra.py
+++ b/throttled/rate_limiter/gcra.py
@@ -31,15 +31,14 @@ class RedisLimitAtomicActionSpec:
     end
 
     local fill_time_for_cost = cost * emission_interval
-    local fill_time_for_capacity = capacity * emission_interval
     local tat = math.max(now, last_tat) + fill_time_for_cost
-    local allow_at = tat - fill_time_for_capacity
-    local time_elapsed = now - allow_at
+    local time_from_tat = now - math.max(now, last_tat)
+    local time_elapsed = time_from_tat + (capacity - cost) * emission_interval
 
     local limited = 0
     local retry_after = 0
     local reset_after = tat - now
-    local remaining = math.floor(time_elapsed / emission_interval)
+    local remaining = (capacity - cost) + math.floor(time_from_tat / emission_interval)
     if remaining < 0 then
         limited = 1
         retry_after = time_elapsed * -1
@@ -75,14 +74,13 @@ class RedisPeekAtomicActionSpec:
         tat= tonumber(tat)
     end
 
-    local fill_time_for_capacity = capacity * emission_interval
-    local allow_at = math.max(tat, now) - fill_time_for_capacity
-    local time_elapsed = now - allow_at
+    local time_from_tat = now - math.max(tat, now)
+    local time_elapsed = time_from_tat + capacity * emission_interval
 
     local limited = 0
     local retry_after = 0
     local reset_after = math.max(0, tat - now)
-    local remaining = math.floor(time_elapsed / emission_interval)
+    local remaining = capacity + math.floor(time_from_tat / emission_interval)
     if remaining < 1 then
         limited = 1
         remaining = 0
@@ -152,12 +150,11 @@ class MemoryLimitActionLogic:
         last_tat: float = float(backend.get(key) or now)
 
         fill_time_for_cost: float = cost * emission_interval
-        fill_time_for_capacity: float = capacity * emission_interval
         tat: float = max(now, last_tat) + fill_time_for_cost
-        allow_at: float = tat - fill_time_for_capacity
-        time_elapsed: float = now - allow_at
+        time_from_tat: float = now - max(now, last_tat)
+        time_elapsed: float = time_from_tat + (capacity - cost) * emission_interval
 
-        remaining: int = math.floor(time_elapsed / emission_interval)
+        remaining: int = capacity - cost + math.floor(time_from_tat / emission_interval)
         limited: int = 0
         retry_after: float = 0.0
         reset_after: float = tat - now
@@ -200,12 +197,11 @@ class MemoryPeekActionLogic:
 
         now: float = utils.now_mono_f()
         tat: float = float(backend.get(key) or now)
-        fill_time_for_capacity: float = capacity * emission_interval
-        allow_at: float = max(now, tat) - fill_time_for_capacity
-        time_elapsed: float = now - allow_at
+        time_from_tat: float = now - max(now, tat)
+        time_elapsed: float = time_from_tat + capacity * emission_interval
 
         reset_after: float = max(0.0, tat - now)
-        remaining: int = math.floor(time_elapsed / emission_interval)
+        remaining: int = capacity + math.floor(time_from_tat / emission_interval)
         limited: int = 0
         retry_after: float = 0.0
         if remaining < 1:

--- a/throttled/rate_limiter/lua/gcra.lua
+++ b/throttled/rate_limiter/lua/gcra.lua
@@ -22,20 +22,18 @@ end
 
 -- Calculate the fill time required for the current cost.
 local fill_time_for_cost = cost * emission_interval
--- Calculate the fill time required for the full capacity.
-local fill_time_for_capacity = capacity * emission_interval
 -- Calculate the theoretical arrival time (TAT) for the current request.
 local tat = math.max(now, last_tat) + fill_time_for_cost
--- Calculate the the time when the request would be allowed.
-local allow_at = tat - fill_time_for_capacity
+-- Calculate the time from the last theoretical arrival time (TAT), at most zero.
+local time_from_tat = now - math.max(now, last_tat)
 -- Calculate the time elapsed since the request would be allowed.
-local time_elapsed = now - allow_at
+local time_elapsed = time_from_tat + (capacity - cost) * emission_interval
 
 
 local limited = 0
 local retry_after = 0
 local reset_after = tat - now
-local remaining = math.floor(time_elapsed / emission_interval)
+local remaining = (capacity - cost) + math.floor(time_from_tat / emission_interval)
 if remaining < 0 then
     limited = 1
     retry_after = time_elapsed * -1

--- a/throttled/rate_limiter/lua/gcra_peek.lua
+++ b/throttled/rate_limiter/lua/gcra_peek.lua
@@ -18,17 +18,15 @@ else
     tat= tonumber(tat)
 end
 
--- Calculate the fill time required for the full capacity.
-local fill_time_for_capacity = capacity * emission_interval
--- Calculate the the time when the request would be allowed.
-local allow_at = math.max(tat, now) - fill_time_for_capacity
+-- Calculate the time from the theoretical arrival time (TAT), at most zero.
+local time_from_tat = now - math.max(tat, now)
 -- Calculate the time elapsed since the request would be allowed.
-local time_elapsed = now - allow_at
+local time_elapsed = time_from_tat + capacity * emission_interval
 
 local limited = 0
 local retry_after = 0
 local reset_after = math.max(0, tat - now)
-local remaining = math.floor(time_elapsed / emission_interval)
+local remaining = capacity + math.floor(time_from_tat / emission_interval)
 if remaining < 1 then
     limited = 1
     remaining = 0


### PR DESCRIPTION
## Summary

GCRA derives its decision boundary as `allow_at = (now + interval) - interval`. For an unseen key that is mathematically `now`, but floating-point rounding can land it just above `now` whenever `now + interval` crosses a power of two; `math.floor` then turns the remaining count negative and the key's very first request is rejected. With `time.monotonic()` as the clock (machine uptime), this hits roughly a quarter to a half of first requests on a recently booted machine - we found it as a CI-only flake that never reproduced on long-lived developer machines. Peek has the same shape: it reports an unseen key as limited whenever the emission interval is not exactly representable in binary (e.g. 1/3s from `per_sec(3)`).

The fix computes the elapsed time directly, which is algebraically identical but exactly zero for an unseen key:

```
time_elapsed = (now - max(now, last_tat)) + (capacity - cost) * emission_interval
```

The integer part also stays out of the floor division, so `remaining` is exact. The same change is applied to the memory logic (shared by sync and async), the inline Lua scripts, and the reference files under `rate_limiter/lua/`. Behavior for existing keys is unchanged: their elapsed time between requests is genuine, dwarfing the ULP-scale rounding.

This PR is designed to be read as two commits:

1. Eight regression tests (sync/async x limit/peek x memory/Redis) marked `xfail(strict=True)`, failing deterministically against the current code.
2. The fix, which flips the tests to plain passing ones.

## Test plan

Each test pins the relevant clock (`throttled.utils.now_mono_f` for memory, `time.time` behind fakeredis's `TIME` for Redis, so the real Lua scripts run) and sweeps 4096 small clock values typical of a recently booted machine. At commit 1 all eight xfail (hundreds of wrong rejections per test); at commit 2 all pass. Full suite: 789 passed; `prek run --all-files` passes at both commits.

Cost of the sweeps: ~0.2s per memory test and ~1s per Redis test (fakeredis + Lua round trips), and no measurable change to suite wall time under `-n auto`. Note the count and range are coupled: the limit tests only trigger once `now + interval` crosses a power of two (from `now ≈ 68` in this sweep), so shrinking the range would remove the triggering region first. I am very open to writing a different test for this if you would prefer another approach.

---

This PR was written with [Claude Code](https://claude.com/claude-code) (AI), directed and reviewed by a human.

